### PR TITLE
Add classifiers for Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,7 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
     )
 )


### PR DESCRIPTION
With a new Python, it just works! :tada: 

![Pyvo calendar](https://cloud.githubusercontent.com/assets/302922/8393724/d9425488-1d1c-11e5-93c1-c8f7556941ec.png)
